### PR TITLE
Add --webdriver-loglevel cli option of phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ options are listed below.
 - `silent: {true|false}`
     - Suppresses messages about starting and stopping the server
     - Default is `false`
+- `webdriverLoglevel: {ERROR|WARN|INFO|DEBUG)}`
+    - WebDriver Logging Level
+    - Defaults to `INFO`
+- `webdriverLogfile: {path}`
+    - File where to write the WebDriver’s Log
 
 ## Usage
 

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -218,6 +218,7 @@ class Phantoman extends \Codeception\Platform\Extension
             'outputEncoding' => '--output-encoding',
             'scriptEncoding' => '--script-encoding',
             'webdriverLoglevel' => '--webdriver-loglevel',
+            'webdriverLogfile' => '--webdriver-logfile',
         );
 
         $params = array();

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -217,6 +217,7 @@ class Phantoman extends \Codeception\Platform\Extension
             'localToRemoteUrlAccess' => '--local-to-remote-url-access',
             'outputEncoding' => '--output-encoding',
             'scriptEncoding' => '--script-encoding',
+            'webdriverLoglevel' => '--webdriver-loglevel',
         );
 
         $params = array();


### PR DESCRIPTION
I added the option ```--webdriver-loglevel``` from the phantomjs cli to use a different loglevel like described in their documentation. It's just one line and option and your code seems to implement it on the fly.