### PR TITLE
Suite config compatibility & cleanup.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and stopping [PhantomJS](http://phantomjs.org/) when running tests.
 
 ## Minimum Requirements
 
-- Codeception 2.1.0
+- Codeception 2.2.7
 - PHP 5.4
 
 ## Installation using [Composer](https://getcomposer.org)
@@ -40,7 +40,7 @@ PhantomJS is used, please set the path as shown in the configuration below.**
 
 By default Phantoman will use the path `vendor/bin/phantomjs` and port `4444`.
 
-All enabling and configuration is done in `codeception.yml`.
+Enabling and configuration can be done in `codeception.yml` or in your suite config file.
 
 ### Enabling Phantoman with defaults
 
@@ -61,6 +61,20 @@ extensions:
             path: '/usr/bin/phantomjs'
             port: 4445
             suites: ['acceptance']
+```
+
+### Enabling Phantoman in the acceptance suite except on the `ci` environment
+```yaml
+extensions:
+  enabled:
+    - Codeception\Extension\Phantoman:
+        suites: ['acceptance']
+env:
+  ci:
+    extensions:
+      enabled:
+        - Codeception\Extension\Phantoman:
+            suites: []
 ```
 
 ### Available options
@@ -95,10 +109,6 @@ options are listed below.
 - `suites: {array|string}`
     - If omitted, PhantomJS is started for all suites.
     - Specify an array of suites or a single suite name.
-        - If you're using an environment (`--env`), Codeception appends the
-          environment name to the suite name in brackets. You need to include
-          each suite/environment combination separately in the array.
-            - `suites: ['acceptance', 'acceptance (staging)', 'acceptance (prod)']`
 - `webSecurity: {true|false}`
     - Enables web security
 - `ignoreSslErrors: {true|false}`
@@ -154,13 +164,13 @@ automatically start the PhantomJS server and wait for it to be accessible before
 proceeding with the tests.
 
 ```bash
-Starting PhantomJS Server
+Starting PhantomJS Server.
 Waiting for the PhantomJS server to be reachable..
-PhantomJS server now accessible
+PhantomJS server now accessible.
 ```
 
 Once the tests are complete, PhantomJS will be shut down.
 
 ```bash
-Stopping PhantomJS Server
+Stopping PhantomJS Server.
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "codeception/codeception": "^2.1"
+        "codeception/codeception": "^2.2.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -22,295 +22,302 @@ use Codeception\Extension;
  *
  * @package Codeception\Extension
  */
-class Phantoman extends Extension {
+class Phantoman extends Extension
+{
 
-  /**
-   * Events to listen to.
-   *
-   * @var array
-   */
-  protected static $events = [
-    Events::SUITE_INIT => 'suiteInit',
-  ];
-
-  /**
-   * A resource representing the PhantomJS process.
-   *
-   * @var resource
-   */
-  private $resource;
-
-  /**
-   * File pointers that correspond to PHP's end of any pipes that are created.
-   *
-   * @var array
-   */
-  private $pipes;
-
-  /**
-   * Phantoman constructor.
-   *
-   * @param array $config
-   *   Current extension configuration.
-   * @param array $options
-   *   Passed running options.
-   *
-   * @throws \Codeception\Exception\ExtensionException
-   */
-  public function __construct(array $config, array $options) {
-    // Codeception has an option called silent, which suppresses the console
-    // output. Unfortunately there is no builtin way to activate this mode for
-    // a single extension. This is why the option will passed from the
-    // extension configuration ($config) to the global configuration ($options);
-    // Note: This must be done before calling the parent constructor.
-    if (isset($config['silent']) && $config['silent']) {
-      $options['silent'] = TRUE;
-    }
-    parent::__construct($config, $options);
-
-    // Set default path for PhantomJS to "vendor/bin/phantomjs" for if it was
-    // installed via composer.
-    if (!isset($this->config['path'])) {
-      $this->config['path'] = 'vendor/bin/phantomjs';
-    }
-
-    // Add .exe extension if running on the windows.
-    if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
-      $this->config['path'] .= '.exe';
-    }
-
-    if (!file_exists(realpath($this->config['path']))) {
-      throw new ExtensionException($this, "PhantomJS executable not found: {$this->config['path']}");
-    }
-
-    // Set default WebDriver port.
-    if (!isset($this->config['port'])) {
-      $this->config['port'] = 4444;
-    }
-
-    // Set default debug mode.
-    if (!isset($this->config['debug'])) {
-      $this->config['debug'] = FALSE;
-    }
-  }
-
-  /**
-   * Stop the server when we get destroyed.
-   */
-  public function __destruct() {
-    $this->stopServer();
-  }
-
-  /**
-   * Start PhantomJS server.
-   *
-   * @throws \Codeception\Exception\ExtensionException
-   */
-  private function startServer() {
-    if ($this->resource !== NULL) {
-      return;
-    }
-
-    $this->writeln(PHP_EOL);
-    $this->writeln('Starting PhantomJS Server.');
-
-    $command = $this->getCommand();
-
-    if ($this->config['debug']) {
-      $this->writeln(PHP_EOL);
-
-      // Output the generated command.
-      $this->writeln('Generated PhantomJS Command:');
-      $this->writeln($command);
-      $this->writeln(PHP_EOL);
-    }
-
-    $descriptorSpec = [
-      ['pipe', 'r'],
-      ['file', $this->getLogDir() . 'phantomjs.output.txt', 'w'],
-      ['file', $this->getLogDir() . 'phantomjs.errors.txt', 'a'],
+    /**
+     * Events to listen to.
+     *
+     * @var array
+     */
+    protected static $events = [
+        Events::SUITE_INIT => 'suiteInit',
     ];
 
-    $this->resource = proc_open($command, $descriptorSpec, $this->pipes, NULL, NULL, ['bypass_shell' => TRUE]);
+    /**
+     * A resource representing the PhantomJS process.
+     *
+     * @var resource
+     */
+    private $resource;
 
-    if (!is_resource($this->resource) || !proc_get_status($this->resource)['running']) {
-      proc_close($this->resource);
-      throw new ExtensionException($this, 'Failed to start PhantomJS server.');
+    /**
+     * File pointers that correspond to PHP's end of any pipes that are created.
+     *
+     * @var array
+     */
+    private $pipes;
+
+    /**
+     * Phantoman constructor.
+     *
+     * @param array $config
+     *   Current extension configuration.
+     * @param array $options
+     *   Passed running options.
+     *
+     * @throws \Codeception\Exception\ExtensionException
+     */
+    public function __construct(array $config, array $options)
+    {
+        // Codeception has an option called silent, which suppresses the console
+        // output. Unfortunately there is no builtin way to activate this mode for
+        // a single extension. This is why the option will passed from the
+        // extension configuration ($config) to the global configuration ($options);
+        // Note: This must be done before calling the parent constructor.
+        if (isset($config['silent']) && $config['silent']) {
+            $options['silent'] = true;
+        }
+        parent::__construct($config, $options);
+
+        // Set default path for PhantomJS to "vendor/bin/phantomjs" for if it was
+        // installed via composer.
+        if (!isset($this->config['path'])) {
+            $this->config['path'] = 'vendor/bin/phantomjs';
+        }
+
+        // Add .exe extension if running on the windows.
+        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
+            $this->config['path'] .= '.exe';
+        }
+
+        if (!file_exists(realpath($this->config['path']))) {
+            throw new ExtensionException($this, "PhantomJS executable not found: {$this->config['path']}");
+        }
+
+        // Set default WebDriver port.
+        if (!isset($this->config['port'])) {
+            $this->config['port'] = 4444;
+        }
+
+        // Set default debug mode.
+        if (!isset($this->config['debug'])) {
+            $this->config['debug'] = false;
+        }
     }
 
-    // Wait till the server is reachable before continuing.
-    $max_checks = 10;
-    $checks = 0;
+    /**
+     * Stop the server when we get destroyed.
+     */
+    public function __destruct()
+    {
+        $this->stopServer();
+    }
 
-    $this->write('Waiting for the PhantomJS server to be reachable.');
-    while (TRUE) {
-      if ($checks >= $max_checks) {
-        throw new ExtensionException($this, 'PhantomJS server never became reachable.');
-      }
+    /**
+     * Start PhantomJS server.
+     *
+     * @throws \Codeception\Exception\ExtensionException
+     */
+    private function startServer()
+    {
+        if ($this->resource !== null) {
+            return;
+        }
 
-      $fp = @fsockopen('127.0.0.1', $this->config['port'], $errCode, $errStr, 10);
-      if ($fp) {
+        $this->writeln(PHP_EOL);
+        $this->writeln('Starting PhantomJS Server.');
+
+        $command = $this->getCommand();
+
+        if ($this->config['debug']) {
+            $this->writeln(PHP_EOL);
+
+            // Output the generated command.
+            $this->writeln('Generated PhantomJS Command:');
+            $this->writeln($command);
+            $this->writeln(PHP_EOL);
+        }
+
+        $descriptorSpec = [
+            ['pipe', 'r'],
+            ['file', $this->getLogDir() . 'phantomjs.output.txt', 'w'],
+            ['file', $this->getLogDir() . 'phantomjs.errors.txt', 'a'],
+        ];
+
+        $this->resource = proc_open($command, $descriptorSpec, $this->pipes, null, null, ['bypass_shell' => true]);
+
+        if (!is_resource($this->resource) || !proc_get_status($this->resource)['running']) {
+            proc_close($this->resource);
+            throw new ExtensionException($this, 'Failed to start PhantomJS server.');
+        }
+
+        // Wait till the server is reachable before continuing.
+        $max_checks = 10;
+        $checks = 0;
+
+        $this->write('Waiting for the PhantomJS server to be reachable.');
+        while (true) {
+            if ($checks >= $max_checks) {
+                throw new ExtensionException($this, 'PhantomJS server never became reachable.');
+            }
+
+            $fp = @fsockopen('127.0.0.1', $this->config['port'], $errCode, $errStr, 10);
+            if ($fp) {
+                $this->writeln('');
+                $this->writeln('PhantomJS server now accessible.');
+                fclose($fp);
+                break;
+            }
+
+            $this->write('.');
+            $checks++;
+
+            // Wait before checking again.
+            sleep(1);
+        }
+
+        // Clear progress line writing.
         $this->writeln('');
-        $this->writeln('PhantomJS server now accessible.');
-        fclose($fp);
-        break;
-      }
-
-      $this->write('.');
-      $checks++;
-
-      // Wait before checking again.
-      sleep(1);
     }
 
-    // Clear progress line writing.
-    $this->writeln('');
-  }
+    /**
+     * Stop PhantomJS server.
+     */
+    private function stopServer()
+    {
+        if ($this->resource !== null) {
+            $this->write('Stopping PhantomJS Server.');
 
-  /**
-   * Stop PhantomJS server.
-   */
-  private function stopServer() {
-    if ($this->resource !== NULL) {
-      $this->write('Stopping PhantomJS Server.');
+            // Wait till the server has been stopped.
+            $max_checks = 10;
+            for ($i = 0; $i < $max_checks; $i++) {
+                // If we're on the last loop, and it's still not shut down, just
+                // unset resource to allow the tests to finish.
+                if ($i === $max_checks - 1 && proc_get_status($this->resource)['running'] === true) {
+                    $this->writeln('');
+                    $this->writeln('Unable to properly shutdown PhantomJS server.');
+                    unset($this->resource);
+                    break;
+                }
 
-      // Wait till the server has been stopped.
-      $max_checks = 10;
-      for ($i = 0; $i < $max_checks; $i++) {
-        // If we're on the last loop, and it's still not shut down, just
-        // unset resource to allow the tests to finish.
-        if ($i === $max_checks - 1 && proc_get_status($this->resource)['running'] === TRUE) {
-          $this->writeln('');
-          $this->writeln('Unable to properly shutdown PhantomJS server.');
-          unset($this->resource);
-          break;
+                // Check if the process has stopped yet.
+                if (proc_get_status($this->resource)['running'] === false) {
+                    $this->writeln('');
+                    $this->writeln('PhantomJS server stopped.');
+                    unset($this->resource);
+                    break;
+                }
+
+                foreach ($this->pipes as $pipe) {
+                    if (is_resource($pipe)) {
+                        fclose($pipe);
+                    }
+                }
+
+                // Terminate the process.
+                // Note: Use of SIGINT adds dependency on PCTNL extension so we
+                // use the integer value instead.
+                proc_terminate($this->resource, 2);
+
+                $this->write('.');
+
+                // Wait before checking again.
+                sleep(1);
+            }
         }
-
-        // Check if the process has stopped yet.
-        if (proc_get_status($this->resource)['running'] === FALSE) {
-          $this->writeln('');
-          $this->writeln('PhantomJS server stopped.');
-          unset($this->resource);
-          break;
-        }
-
-        foreach ($this->pipes as $pipe) {
-          if (is_resource($pipe)) {
-            fclose($pipe);
-          }
-        }
-
-        // Terminate the process.
-        // Note: Use of SIGINT adds dependency on PCTNL extension so we
-        // use the integer value instead.
-        proc_terminate($this->resource, 2);
-
-        $this->write('.');
-
-        // Wait before checking again.
-        sleep(1);
-      }
-    }
-  }
-
-  /**
-   * Build the parameters for our command.
-   *
-   * @return string
-   *   All parameters separated by spaces.
-   */
-  private function getCommandParameters() {
-    // Map our config options to PhantomJS options.
-    $mapping = [
-      'port' => '--webdriver',
-      'proxy' => '--proxy',
-      'proxyType' => '--proxy-type',
-      'proxyAuth' => '--proxy-auth',
-      'webSecurity' => '--web-security',
-      'ignoreSslErrors' => '--ignore-ssl-errors',
-      'sslProtocol' => '--ssl-protocol',
-      'sslCertificatesPath' => '--ssl-certificates-path',
-      'remoteDebuggerPort' => '--remote-debugger-port',
-      'remoteDebuggerAutorun' => '--remote-debugger-autorun',
-      'cookiesFile' => '--cookies-file',
-      'diskCache' => '--disk-cache',
-      'maxDiskCacheSize' => '--max-disk-cache-size',
-      'loadImage' => '--load-images',
-      'localStoragePath' => '--local-storage-path',
-      'localStorageQuota' => '--local-storage-quota',
-      'localToRemoteUrlAccess' => '--local-to-remote-url-access',
-      'outputEncoding' => '--output-encoding',
-      'scriptEncoding' => '--script-encoding',
-      'webdriverLoglevel' => '--webdriver-loglevel',
-      'webdriverLogfile' => '--webdriver-logfile',
-    ];
-
-    $params = [];
-    foreach ($this->config as $configKey => $configValue) {
-      if (!empty($mapping[$configKey])) {
-        if (is_bool($configValue)) {
-          // Make sure the value is true/false and not 1/0.
-          $configValue = $configValue ? 'true' : 'false';
-        }
-        $params[] = $mapping[$configKey] . '=' . $configValue;
-      }
     }
 
-    return implode(' ', $params);
-  }
+    /**
+     * Build the parameters for our command.
+     *
+     * @return string
+     *   All parameters separated by spaces.
+     */
+    private function getCommandParameters()
+    {
+        // Map our config options to PhantomJS options.
+        $mapping = [
+            'port' => '--webdriver',
+            'proxy' => '--proxy',
+            'proxyType' => '--proxy-type',
+            'proxyAuth' => '--proxy-auth',
+            'webSecurity' => '--web-security',
+            'ignoreSslErrors' => '--ignore-ssl-errors',
+            'sslProtocol' => '--ssl-protocol',
+            'sslCertificatesPath' => '--ssl-certificates-path',
+            'remoteDebuggerPort' => '--remote-debugger-port',
+            'remoteDebuggerAutorun' => '--remote-debugger-autorun',
+            'cookiesFile' => '--cookies-file',
+            'diskCache' => '--disk-cache',
+            'maxDiskCacheSize' => '--max-disk-cache-size',
+            'loadImage' => '--load-images',
+            'localStoragePath' => '--local-storage-path',
+            'localStorageQuota' => '--local-storage-quota',
+            'localToRemoteUrlAccess' => '--local-to-remote-url-access',
+            'outputEncoding' => '--output-encoding',
+            'scriptEncoding' => '--script-encoding',
+            'webdriverLoglevel' => '--webdriver-loglevel',
+            'webdriverLogfile' => '--webdriver-logfile',
+        ];
 
-  /**
-   * Get PhantomJS command.
-   *
-   * @return string
-   *   Command to execute.
-   */
-  private function getCommand() {
-    // Prefix command with exec on non Windows systems to ensure that we
-    // receive the correct pid.
-    // See http://php.net/manual/en/function.proc-get-status.php#93382
-    $commandPrefix = $this->isWindows() ? '' : 'exec ';
-    return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
-  }
+        $params = [];
+        foreach ($this->config as $configKey => $configValue) {
+            if (!empty($mapping[$configKey])) {
+                if (is_bool($configValue)) {
+                    // Make sure the value is true/false and not 1/0.
+                    $configValue = $configValue ? 'true' : 'false';
+                }
+                $params[] = $mapping[$configKey] . '=' . $configValue;
+            }
+        }
 
-  /**
-   * Checks if the current machine is Windows.
-   *
-   * @return bool
-   *   True if the machine is windows.
-   */
-  private function isWindows() {
-    return stripos(PHP_OS, 'WIN') === 0;
-  }
-
-  /**
-   * Suite Init.
-   *
-   * @param \Codeception\Event\SuiteEvent $e
-   *   The event with suite, result and settings.
-   *
-   * @throws \Codeception\Exception\ExtensionException
-   */
-  public function suiteInit(SuiteEvent $e) {
-    // Check if PhantomJS should only be started for specific suites.
-    if (isset($this->config['suites'])) {
-      if (is_string($this->config['suites'])) {
-        $suites = [$this->config['suites']];
-      }
-      else {
-        $suites = $this->config['suites'];
-      }
-
-      // If the current suites aren't in the desired array, return without
-      // starting PhantomJS.
-      if (!in_array($e->getSuite()->getBaseName(), $suites, TRUE)
-        && !in_array($e->getSuite()->getName(), $suites, TRUE)) {
-        return;
-      }
+        return implode(' ', $params);
     }
 
-    // Start the PhantomJS server.
-    $this->startServer();
-  }
+    /**
+     * Get PhantomJS command.
+     *
+     * @return string
+     *   Command to execute.
+     */
+    private function getCommand()
+    {
+        // Prefix command with exec on non Windows systems to ensure that we
+        // receive the correct pid.
+        // See http://php.net/manual/en/function.proc-get-status.php#93382
+        $commandPrefix = $this->isWindows() ? '' : 'exec ';
+        return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+    }
 
+    /**
+     * Checks if the current machine is Windows.
+     *
+     * @return bool
+     *   True if the machine is windows.
+     */
+    private function isWindows()
+    {
+        return stripos(PHP_OS, 'WIN') === 0;
+    }
+
+    /**
+     * Suite Init.
+     *
+     * @param \Codeception\Event\SuiteEvent $e
+     *   The event with suite, result and settings.
+     *
+     * @throws \Codeception\Exception\ExtensionException
+     */
+    public function suiteInit(SuiteEvent $e)
+    {
+        // Check if PhantomJS should only be started for specific suites.
+        if (isset($this->config['suites'])) {
+            if (is_string($this->config['suites'])) {
+                $suites = [$this->config['suites']];
+            } else {
+                $suites = $this->config['suites'];
+            }
+
+            // If the current suites aren't in the desired array, return without
+            // starting PhantomJS.
+            if (!in_array($e->getSuite()->getBaseName(), $suites, true)
+                && !in_array($e->getSuite()->getName(), $suites, true)) {
+                return;
+            }
+        }
+
+        // Start the PhantomJS server.
+        $this->startServer();
+    }
 }

--- a/src/Phantoman.php
+++ b/src/Phantoman.php
@@ -1,6 +1,9 @@
 <?php
+
+namespace Codeception\Extension;
+
 /**
- * Phantoman
+ * Phantoman.
  *
  * The Codeception extension for automatically starting and stopping PhantomJS
  * when running tests.
@@ -9,275 +12,305 @@
  * https://github.com/tiger-seo/PhpBuiltinServer
  */
 
-namespace Codeception\Extension;
-
+use Codeception\Event\SuiteEvent;
+use Codeception\Events;
 use Codeception\Exception\ExtensionException;
+use Codeception\Extension;
 
-class Phantoman extends \Codeception\Platform\Extension
-{
-    // list events to listen to
-    static $events = array(
-        'module.init' => 'moduleInit',
-    );
+/**
+ * Class Phantoman.
+ *
+ * @package Codeception\Extension
+ */
+class Phantoman extends Extension {
 
-    private $resource;
+  /**
+   * Events to listen to.
+   *
+   * @var array
+   */
+  protected static $events = [
+    Events::SUITE_INIT => 'suiteInit',
+  ];
 
-    private $pipes;
+  /**
+   * A resource representing the PhantomJS process.
+   *
+   * @var resource
+   */
+  private $resource;
 
-    public function __construct($config, $options)
-    {
-        // Codeception has an option called silent, which suppresses the console output.
-        // Unfortunately there is no builtin way to activate this mode for a single extension.
-        // This is why the option will passed from the extension configuration ($config)
-        // to the global configuration ($options);
-        // Note: This must be done before calling the parent constructor.
-        if (isset($config['silent']) && $config['silent']) {
-            $options['silent'] = true;
-        }
+  /**
+   * File pointers that correspond to PHP's end of any pipes that are created.
+   *
+   * @var array
+   */
+  private $pipes;
 
-        parent::__construct($config, $options);
+  /**
+   * Phantoman constructor.
+   *
+   * @param array $config
+   *   Current extension configuration.
+   * @param array $options
+   *   Passed running options.
+   *
+   * @throws \Codeception\Exception\ExtensionException
+   */
+  public function __construct(array $config, array $options) {
+    // Codeception has an option called silent, which suppresses the console
+    // output. Unfortunately there is no builtin way to activate this mode for
+    // a single extension. This is why the option will passed from the
+    // extension configuration ($config) to the global configuration ($options);
+    // Note: This must be done before calling the parent constructor.
+    if (isset($config['silent']) && $config['silent']) {
+      $options['silent'] = TRUE;
+    }
+    parent::__construct($config, $options);
 
-        // Set default path for PhantomJS to "vendor/bin/phantomjs" for if it was installed via composer
-        if (!isset($this->config['path'])) {
-            $this->config['path'] = 'vendor/bin/phantomjs';
-        }
-
-        // If a directory was provided for the path, use old method of appending PhantomJS
-        if (is_dir(realpath($this->config['path']))) {
-            // Show warning that this is being deprecated
-            $this->writeln(PHP_EOL);
-            $this->writeln('WARNING: The PhantomJS path for Phantoman is set to a directory, this is being deprecated in the future. Please update your Phantoman configuration to be the full path to PhantomJS.');
-
-            $this->config['path'] .= '/phantomjs';
-        }
-
-        // Add .exe extension if running on the windows
-        if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
-            $this->config['path'] .= '.exe';
-        }
-
-        if (!file_exists(realpath($this->config['path']))) {
-            throw new ExtensionException($this, "File not found: {$this->config['path']}.");
-        }
-
-        // Set default WebDriver port
-        if (!isset($this->config['port'])) {
-            $this->config['port'] = 4444;
-        }
-
-        // Set default debug mode
-        if (!isset($this->config['debug'])) {
-            $this->config['debug'] = false;
-        }
+    // Set default path for PhantomJS to "vendor/bin/phantomjs" for if it was
+    // installed via composer.
+    if (!isset($this->config['path'])) {
+      $this->config['path'] = 'vendor/bin/phantomjs';
     }
 
-    public function __destruct()
-    {
-        $this->stopServer();
+    // Add .exe extension if running on the windows.
+    if ($this->isWindows() && file_exists(realpath($this->config['path'] . '.exe'))) {
+      $this->config['path'] .= '.exe';
     }
 
-    /**
-     * Start PhantomJS server
-     */
-    private function startServer()
-    {
-        if ($this->resource !== null) {
-            return;
-        }
+    if (!file_exists(realpath($this->config['path']))) {
+      throw new ExtensionException($this, "PhantomJS executable not found: {$this->config['path']}");
+    }
 
-        $this->writeln(PHP_EOL);
-        $this->writeln('Starting PhantomJS Server');
+    // Set default WebDriver port.
+    if (!isset($this->config['port'])) {
+      $this->config['port'] = 4444;
+    }
 
-        $command = $this->getCommand();
+    // Set default debug mode.
+    if (!isset($this->config['debug'])) {
+      $this->config['debug'] = FALSE;
+    }
+  }
 
-        if ($this->config['debug']) {
-            $this->writeln(PHP_EOL);
+  /**
+   * Stop the server when we get destroyed.
+   */
+  public function __destruct() {
+    $this->stopServer();
+  }
 
-            // Output the generated command
-            $this->writeln('Generated PhantomJS Command:');
-            $this->writeln($command);
+  /**
+   * Start PhantomJS server.
+   *
+   * @throws \Codeception\Exception\ExtensionException
+   */
+  private function startServer() {
+    if ($this->resource !== NULL) {
+      return;
+    }
 
-            $this->writeln(PHP_EOL);
-        }
+    $this->writeln(PHP_EOL);
+    $this->writeln('Starting PhantomJS Server.');
 
-        $descriptorSpec = array(
-            array('pipe', 'r'),
-            array('file', $this->getLogDir() . 'phantomjs.output.txt', 'w'),
-            array('file', $this->getLogDir() . 'phantomjs.errors.txt', 'a')
-        );
+    $command = $this->getCommand();
 
-        $this->resource = proc_open($command, $descriptorSpec, $this->pipes, null, null, array('bypass_shell' => true));
+    if ($this->config['debug']) {
+      $this->writeln(PHP_EOL);
 
-        if (!is_resource($this->resource) || !proc_get_status($this->resource)['running']) {
-            proc_close($this->resource);
-            throw new ExtensionException($this, 'Failed to start PhantomJS server.');
-        }
+      // Output the generated command.
+      $this->writeln('Generated PhantomJS Command:');
+      $this->writeln($command);
+      $this->writeln(PHP_EOL);
+    }
 
-        // Wait till the server is reachable before continuing
-        $max_checks = 10;
-        $checks = 0;
+    $descriptorSpec = [
+      ['pipe', 'r'],
+      ['file', $this->getLogDir() . 'phantomjs.output.txt', 'w'],
+      ['file', $this->getLogDir() . 'phantomjs.errors.txt', 'a'],
+    ];
 
-        $this->write('Waiting for the PhantomJS server to be reachable');
-        while (true) {
-            if ($checks >= $max_checks) {
-                throw new ExtensionException($this, 'PhantomJS server never became reachable');
-                break;
-            }
+    $this->resource = proc_open($command, $descriptorSpec, $this->pipes, NULL, NULL, ['bypass_shell' => TRUE]);
 
-            if ($fp = @fsockopen('127.0.0.1', $this->config['port'], $errCode, $errStr, 10)) {
-                $this->writeln('');
-                $this->writeln('PhantomJS server now accessible');
-                fclose($fp);
-                break;
-            }
+    if (!is_resource($this->resource) || !proc_get_status($this->resource)['running']) {
+      proc_close($this->resource);
+      throw new ExtensionException($this, 'Failed to start PhantomJS server.');
+    }
 
-            $this->write('.');
-            $checks++;
+    // Wait till the server is reachable before continuing.
+    $max_checks = 10;
+    $checks = 0;
 
-            // Wait before checking again
-            sleep(1);
-        }
+    $this->write('Waiting for the PhantomJS server to be reachable.');
+    while (TRUE) {
+      if ($checks >= $max_checks) {
+        throw new ExtensionException($this, 'PhantomJS server never became reachable.');
+      }
 
-        // Clear progress line writing
+      $fp = @fsockopen('127.0.0.1', $this->config['port'], $errCode, $errStr, 10);
+      if ($fp) {
         $this->writeln('');
+        $this->writeln('PhantomJS server now accessible.');
+        fclose($fp);
+        break;
+      }
+
+      $this->write('.');
+      $checks++;
+
+      // Wait before checking again.
+      sleep(1);
     }
 
-    /**
-     * Stop PhantomJS server
-     */
-    private function stopServer()
-    {
-        if ($this->resource !== null) {
-            $this->write('Stopping PhantomJS Server');
+    // Clear progress line writing.
+    $this->writeln('');
+  }
 
-            // Wait till the server has been stopped
-            $max_checks = 10;
-            for ($i = 0; $i < $max_checks; $i++) {
-                // If we're on the last loop, and it's still not shut down, just
-                // unset resource to allow the tests to finish
-                if ($i == $max_checks - 1 && proc_get_status($this->resource)['running'] == true) {
-                    $this->writeln('');
-                    $this->writeln('Unable to properly shutdown PhantomJS server');
-                    unset($this->resource);
-                    break;
-                }
+  /**
+   * Stop PhantomJS server.
+   */
+  private function stopServer() {
+    if ($this->resource !== NULL) {
+      $this->write('Stopping PhantomJS Server.');
 
-                // Check if the process has stopped yet
-                if (proc_get_status($this->resource)['running'] == false) {
-                    $this->writeln('');
-                    $this->writeln('PhantomJS server stopped');
-                    unset($this->resource);
-                    break;
-                }
-
-                foreach ($this->pipes as $pipe) {
-                    if (is_resource($pipe)) {
-                        fclose($pipe);
-                    }
-                }
-
-                // Terminate the process
-                // Note: Use of SIGINT adds dependency on PCTNL extension so we
-                // use the integer value instead
-                proc_terminate($this->resource, 2);
-
-                $this->write('.');
-
-                // Wait before checking again
-                sleep(1);
-            }
-        }
-    }
-
-    /**
-     * getCommandParameters
-     *
-     * @return string
-     */
-    private function getCommandParameters()
-    {
-        // Map our config options to PhantomJS options
-        $mapping = array(
-            'port' => '--webdriver',
-            'proxy' => '--proxy',
-            'proxyType' => '--proxy-type',
-            'proxyAuth' => '--proxy-auth',
-            'webSecurity' => '--web-security',
-            'ignoreSslErrors' => '--ignore-ssl-errors',
-            'sslProtocol' => '--ssl-protocol',
-            'sslCertificatesPath' => '--ssl-certificates-path',
-            'remoteDebuggerPort' => '--remote-debugger-port',
-            'remoteDebuggerAutorun' => '--remote-debugger-autorun',
-            'cookiesFile' => '--cookies-file',
-            'diskCache' => '--disk-cache',
-            'maxDiskCacheSize' => '--max-disk-cache-size',
-            'loadImage' => '--load-images',
-            'localStoragePath' => '--local-storage-path',
-            'localStorageQuota' => '--local-storage-quota',
-            'localToRemoteUrlAccess' => '--local-to-remote-url-access',
-            'outputEncoding' => '--output-encoding',
-            'scriptEncoding' => '--script-encoding',
-            'webdriverLoglevel' => '--webdriver-loglevel',
-            'webdriverLogfile' => '--webdriver-logfile',
-        );
-
-        $params = array();
-        foreach ($this->config as $configKey => $configValue) {
-            if (!empty($mapping[$configKey])) {
-                if (is_bool($configValue)) {
-                    // Make sure the value is true/false and not 1/0
-                    $configValue = ($configValue) ? 'true' : 'false';
-                }
-                $params[] = $mapping[$configKey] . '=' . $configValue;
-            }
+      // Wait till the server has been stopped.
+      $max_checks = 10;
+      for ($i = 0; $i < $max_checks; $i++) {
+        // If we're on the last loop, and it's still not shut down, just
+        // unset resource to allow the tests to finish.
+        if ($i === $max_checks - 1 && proc_get_status($this->resource)['running'] === TRUE) {
+          $this->writeln('');
+          $this->writeln('Unable to properly shutdown PhantomJS server.');
+          unset($this->resource);
+          break;
         }
 
-        return implode(' ', $params);
-    }
-
-    /**
-     * Get PhantomJS command
-     */
-    private function getCommand()
-    {
-        // Prefix command with exec on non Windows systems to ensure that we receive the correct pid.
-        // See http://php.net/manual/en/function.proc-get-status.php#93382
-        $commandPrefix = $this->isWindows() ? '' : 'exec ';
-        return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
-    }
-
-    /**
-     * Checks if the current machine is Windows.
-     *
-     * @return bool True if the machine is windows.
-     * @see http://stackoverflow.com/questions/5879043/php-script-detect-whether-running-under-linux-or-windows
-     */
-    private function isWindows()
-    {
-        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
-    }
-
-    /**
-     * Module Init
-     */
-    public function moduleInit(\Codeception\Event\SuiteEvent $e)
-    {
-        // Check if PhantomJS should only be started for specific suites
-        if (isset($this->config['suites'])) {
-            if (is_string($this->config['suites'])) {
-                $suites = [$this->config['suites']];
-            } else {
-                $suites = $this->config['suites'];
-            }
-
-            // If the current suites aren't in the desired array, return without starting PhantomJS
-            if (!in_array($e->getSuite()->getBaseName(), $suites)
-                && !in_array($e->getSuite()->getName(), $suites)) {
-                return;
-            }
+        // Check if the process has stopped yet.
+        if (proc_get_status($this->resource)['running'] === FALSE) {
+          $this->writeln('');
+          $this->writeln('PhantomJS server stopped.');
+          unset($this->resource);
+          break;
         }
 
-        // Start the PhantomJS server
-        $this->startServer();
+        foreach ($this->pipes as $pipe) {
+          if (is_resource($pipe)) {
+            fclose($pipe);
+          }
+        }
+
+        // Terminate the process.
+        // Note: Use of SIGINT adds dependency on PCTNL extension so we
+        // use the integer value instead.
+        proc_terminate($this->resource, 2);
+
+        $this->write('.');
+
+        // Wait before checking again.
+        sleep(1);
+      }
     }
+  }
+
+  /**
+   * Build the parameters for our command.
+   *
+   * @return string
+   *   All parameters separated by spaces.
+   */
+  private function getCommandParameters() {
+    // Map our config options to PhantomJS options.
+    $mapping = [
+      'port' => '--webdriver',
+      'proxy' => '--proxy',
+      'proxyType' => '--proxy-type',
+      'proxyAuth' => '--proxy-auth',
+      'webSecurity' => '--web-security',
+      'ignoreSslErrors' => '--ignore-ssl-errors',
+      'sslProtocol' => '--ssl-protocol',
+      'sslCertificatesPath' => '--ssl-certificates-path',
+      'remoteDebuggerPort' => '--remote-debugger-port',
+      'remoteDebuggerAutorun' => '--remote-debugger-autorun',
+      'cookiesFile' => '--cookies-file',
+      'diskCache' => '--disk-cache',
+      'maxDiskCacheSize' => '--max-disk-cache-size',
+      'loadImage' => '--load-images',
+      'localStoragePath' => '--local-storage-path',
+      'localStorageQuota' => '--local-storage-quota',
+      'localToRemoteUrlAccess' => '--local-to-remote-url-access',
+      'outputEncoding' => '--output-encoding',
+      'scriptEncoding' => '--script-encoding',
+      'webdriverLoglevel' => '--webdriver-loglevel',
+      'webdriverLogfile' => '--webdriver-logfile',
+    ];
+
+    $params = [];
+    foreach ($this->config as $configKey => $configValue) {
+      if (!empty($mapping[$configKey])) {
+        if (is_bool($configValue)) {
+          // Make sure the value is true/false and not 1/0.
+          $configValue = $configValue ? 'true' : 'false';
+        }
+        $params[] = $mapping[$configKey] . '=' . $configValue;
+      }
+    }
+
+    return implode(' ', $params);
+  }
+
+  /**
+   * Get PhantomJS command.
+   *
+   * @return string
+   *   Command to execute.
+   */
+  private function getCommand() {
+    // Prefix command with exec on non Windows systems to ensure that we
+    // receive the correct pid.
+    // See http://php.net/manual/en/function.proc-get-status.php#93382
+    $commandPrefix = $this->isWindows() ? '' : 'exec ';
+    return $commandPrefix . escapeshellarg(realpath($this->config['path'])) . ' ' . $this->getCommandParameters();
+  }
+
+  /**
+   * Checks if the current machine is Windows.
+   *
+   * @return bool
+   *   True if the machine is windows.
+   */
+  private function isWindows() {
+    return stripos(PHP_OS, 'WIN') === 0;
+  }
+
+  /**
+   * Suite Init.
+   *
+   * @param \Codeception\Event\SuiteEvent $e
+   *   The event with suite, result and settings.
+   *
+   * @throws \Codeception\Exception\ExtensionException
+   */
+  public function suiteInit(SuiteEvent $e) {
+    // Check if PhantomJS should only be started for specific suites.
+    if (isset($this->config['suites'])) {
+      if (is_string($this->config['suites'])) {
+        $suites = [$this->config['suites']];
+      }
+      else {
+        $suites = $this->config['suites'];
+      }
+
+      // If the current suites aren't in the desired array, return without
+      // starting PhantomJS.
+      if (!in_array($e->getSuite()->getBaseName(), $suites, TRUE)
+        && !in_array($e->getSuite()->getName(), $suites, TRUE)) {
+        return;
+      }
+    }
+
+    // Start the PhantomJS server.
+    $this->startServer();
+  }
+
 }


### PR DESCRIPTION
Sorry, I should have done the cleanup and the functional changes in separate commits.

Functionally:
- Removed deprecated ability to specify directory to PhantomJS path.
- Extended `\Codeception\Extension` rather than `\Codeception\Platform\Extension`.
- Updated doc to describe way to exclude Phantoman in certain environment.
- Subscribe to SUITE_INIT events rather than MODULE_INIT events.

